### PR TITLE
[FE] 메인 페이지 컴포넌트 생성

### DIFF
--- a/FE/package.json
+++ b/FE/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -1,9 +1,11 @@
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
 import "./App.scss";
-import Login from "./pages/Login";
-import NewRecomand from "./routes/NewRecomand";
-import NewChatRoom from "./routes/NewChatRoom";
-import Signup from "./routes/Signup";
+import Login from "@pages/Login";
+import HomePage from "@pages/HomePage";
+import CommonPage from "@pages/CommonPage";
+import NewRecomand from "@routes/NewRecomand";
+import NewChatRoom from "@routes/NewChatRoom";
+import Signup from "@routes/Signup";
 
 function App() {
   return (
@@ -12,8 +14,7 @@ function App() {
         <Route path="/" element={<Login />} />
         <Route path="/signup/*" element={<Signup />} />
 
-        <Route path="/home/chatroom" element={<div>홈 단톡방</div>} />
-        <Route path="/home/recommend" element={<div>홈 추천글</div>} />
+        <Route path="/home/*" element={<HomePage />} />
 
         <Route path="/chatroom/:id" element={<div>단톡방 상세</div>} />
         <Route path="/chatroomlist" element={<div>단톡방 리스트</div>} />
@@ -26,6 +27,7 @@ function App() {
 
         <Route path="/mypage" element={<div>마이페이지</div>} />
         <Route path="/profile/:userId" element={<div>상대방 프로필</div>} />
+        <Route path="/common" element={<CommonPage />} />
         <Route path="*" element={<div>잘못된 경로</div>} />
       </Routes>
     </>

--- a/FE/src/components/common/Logo/index.tsx
+++ b/FE/src/components/common/Logo/index.tsx
@@ -1,0 +1,14 @@
+import styles from "@styles/common/Logo.module.scss";
+import Text from "../Text";
+
+const Logo = () => {
+  return (
+    <div className={styles.logo}>
+      <Text types="display" bold="semi-bold">
+        LOGO
+      </Text>
+    </div>
+  );
+};
+
+export default Logo;

--- a/FE/src/components/common/Profile/index.tsx
+++ b/FE/src/components/common/Profile/index.tsx
@@ -1,0 +1,21 @@
+import styles from "@styles/common/Profile.module.scss";
+import { Avatar } from "@mui/material";
+import Text from "../Text";
+
+interface Props {
+  name: string;
+  onClick?: () => void;
+}
+
+const Profile = ({ name, ...rest }: Props) => {
+  return (
+    <div className={styles.profile} {...rest}>
+      <Avatar />
+      <Text types="title" bold="semi-bold">
+        {name}
+      </Text>
+    </div>
+  );
+};
+
+export default Profile;

--- a/FE/src/components/common/Tag/index.tsx
+++ b/FE/src/components/common/Tag/index.tsx
@@ -1,4 +1,3 @@
-import { MouseEventHandler } from "react";
 import styles from "@styles/common/Tag.module.scss";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   types?: "primary" | "secondary" | "gray";
   checked?: boolean;
   clickable?: boolean;
-  onClick?: MouseEventHandler<HTMLDivElement>;
+  onClick?: () => void;
 }
 
 const Tag = ({ label, size, types = "primary", clickable = false, ...rest }: Props) => {

--- a/FE/src/components/home/BottomNav.tsx
+++ b/FE/src/components/home/BottomNav.tsx
@@ -1,0 +1,34 @@
+import styles from "@styles/home/Home.module.scss";
+import HomeIcon from "@mui/icons-material/Home";
+import SearchIcon from "@mui/icons-material/Search";
+import FaceIcon from "@mui/icons-material/Face";
+import { useNavigate } from "react-router-dom";
+
+const ButtomNav = () => {
+  const navigate = useNavigate();
+  const handleHome = () => {
+    navigate("/home");
+  };
+
+  const handleSearch = () => {
+    navigate("/chatroom/search");
+  };
+
+  const handleMyPage = () => {};
+
+  return (
+    <div className={styles.nav}>
+      <div onClick={handleHome}>
+        <HomeIcon />
+      </div>
+      <div onClick={handleSearch}>
+        <SearchIcon />
+      </div>
+      <div onClick={handleMyPage}>
+        <FaceIcon />
+      </div>
+    </div>
+  );
+};
+
+export default ButtomNav;

--- a/FE/src/components/home/HomeTab.tsx
+++ b/FE/src/components/home/HomeTab.tsx
@@ -1,0 +1,35 @@
+import { useNavigate } from "react-router-dom";
+import styles from "@styles/home/Home.module.scss";
+import Text from "../common/Text";
+
+const HomeTab = () => {
+  const navigate = useNavigate();
+  const clicked = window.location.pathname === "/home" ? "--clicked" : "";
+
+  const handleChatroom = () => {
+    navigate("/home");
+  };
+
+  const handleRecommend = () => {
+    navigate("/home/recommend");
+  };
+
+  return (
+    <div className={styles.tabList}>
+      <div className={styles[`tab__chat${clicked}`]} onClick={handleChatroom}>
+        <Text types="headline" bold="semi-bold">
+          채팅
+        </Text>
+        {clicked !== "" && <div />}
+      </div>
+      <div className={styles[`tab__feed${clicked}`]} onClick={handleRecommend}>
+        <Text types="headline" bold="semi-bold">
+          피드
+        </Text>
+        {clicked === "" && <div />}
+      </div>
+    </div>
+  );
+};
+
+export default HomeTab;

--- a/FE/src/components/home/chatroom/ChatRoomList.tsx
+++ b/FE/src/components/home/chatroom/ChatRoomList.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from "react";
+import styles from "@styles/home/Home.module.scss";
+import Text from "@components/common/Text";
+import Arrow from "@/components/common/Arrow";
+
+interface Props {
+  title: string;
+  subtitle: string;
+  component: ReactNode;
+  onClick?: () => void;
+}
+
+const ChatRoomList = ({ title, subtitle, component }: Props) => {
+  return (
+    <div>
+      <div className={styles.chatroom__title}>
+        <div>
+          <Text types="sub-header" bold="semi-bold">
+            {title}
+          </Text>
+          <Arrow onClick={() => console.log("더보기")} />
+        </div>
+        <Text types="body-1">{subtitle}</Text>
+      </div>
+      {component}
+    </div>
+  );
+};
+
+export default ChatRoomList;

--- a/FE/src/components/home/chatroom/MyChatRoom.tsx
+++ b/FE/src/components/home/chatroom/MyChatRoom.tsx
@@ -1,0 +1,26 @@
+import styles from "@styles/home/Home.module.scss";
+import Text from "@components/common/Text";
+import MyChatRoomItem from "@components/home/chatroom/MyChatRoomItem";
+
+const MyChatRoom = () => {
+  return (
+    <div>
+      <Text types="sub-header" bold="semi-bold">
+        내가 참여 중인 Talk
+      </Text>
+      <div className={styles.webtoon}>
+        <div className={styles.webtoon__items}>
+          <MyChatRoomItem />
+          <MyChatRoomItem />
+          <MyChatRoomItem />
+          <MyChatRoomItem />
+          <MyChatRoomItem />
+          <MyChatRoomItem />
+          <MyChatRoomItem />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MyChatRoom;

--- a/FE/src/components/home/chatroom/MyChatRoomItem.tsx
+++ b/FE/src/components/home/chatroom/MyChatRoomItem.tsx
@@ -1,0 +1,15 @@
+import styles from "@styles/home/Home.module.scss";
+import Text from "@components/common/Text";
+
+const MyChatRoomItem = () => {
+  return (
+    <div className={styles.webtoon__item}>
+      <div className={styles.webtoon__img}></div>
+      <Text types="body-2" bold="medium">
+        웹툰 이름
+      </Text>
+    </div>
+  );
+};
+
+export default MyChatRoomItem;

--- a/FE/src/components/home/chatroom/RankingChat.tsx
+++ b/FE/src/components/home/chatroom/RankingChat.tsx
@@ -1,0 +1,14 @@
+import styles from "@styles/home/Home.module.scss";
+import RankingChatItem from "@components/home/chatroom/RankingChatItem";
+
+const RankingChat = () => {
+  return (
+    <div className={styles.ranking}>
+      <RankingChatItem />
+      <RankingChatItem />
+      <RankingChatItem />
+    </div>
+  );
+};
+
+export default RankingChat;

--- a/FE/src/components/home/chatroom/RankingChatItem.tsx
+++ b/FE/src/components/home/chatroom/RankingChatItem.tsx
@@ -1,0 +1,25 @@
+import styles from "@styles/home/Home.module.scss";
+import Tag from "@/components/common/Tag";
+import Text from "@components/common/Text";
+
+const RankingChatItem = () => {
+  return (
+    <div className={styles.ranking__item}>
+      <div className={styles.ranking__img}>
+        <div />
+        <Tag label="🔥 NN" size="small" />
+      </div>
+      <div>
+        <Text types="title" bold="semi-bold">
+          웹툰 이름입니다.
+        </Text>
+        <div className={styles.ranking__comments}>
+          <Text>최신 댓글입니다.</Text>
+          <Text>최신 댓글입니다.</Text>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RankingChatItem;

--- a/FE/src/components/home/chatroom/RestChat.tsx
+++ b/FE/src/components/home/chatroom/RestChat.tsx
@@ -1,0 +1,14 @@
+import styles from "@styles/home/Home.module.scss";
+import RestChatItem from "@components/home/chatroom/RestChatItem";
+
+const RestChat = () => {
+  return (
+    <div className={styles.rest}>
+      <RestChatItem />
+      <RestChatItem />
+      <RestChatItem />
+    </div>
+  );
+};
+
+export default RestChat;

--- a/FE/src/components/home/chatroom/RestChatItem.tsx
+++ b/FE/src/components/home/chatroom/RestChatItem.tsx
@@ -1,0 +1,23 @@
+import styles from "@styles/home/Home.module.scss";
+import Tag from "@components/common/Tag";
+import Text from "@components/common/Text";
+
+const RestChatItem = () => {
+  return (
+    <div className={styles.rest__item}>
+      <div>
+        <Text types="body-2" bold="medium">
+          웹툰 이름입니다.
+        </Text>
+        <Text>소개글</Text>
+        <div className={styles.rest__tags}>
+          <Tag label="# 태그" types="gray" size="big" />
+          <Tag label="# 태그" types="gray" size="big" />
+        </div>
+      </div>
+      <div className={styles.rest__img}></div>
+    </div>
+  );
+};
+
+export default RestChatItem;

--- a/FE/src/components/home/chatroom/TodayChat.tsx
+++ b/FE/src/components/home/chatroom/TodayChat.tsx
@@ -1,0 +1,14 @@
+import styles from "@styles/home/Home.module.scss";
+import TodayChatItem from "@components/home/chatroom/TodayChatItem";
+
+const TodayChat = () => {
+  return (
+    <div className={styles.today}>
+      <TodayChatItem />
+      <TodayChatItem />
+      <TodayChatItem />
+    </div>
+  );
+};
+
+export default TodayChat;

--- a/FE/src/components/home/chatroom/TodayChatItem.tsx
+++ b/FE/src/components/home/chatroom/TodayChatItem.tsx
@@ -1,0 +1,28 @@
+import styles from "@styles/home/Home.module.scss";
+import Tag from "@components/common/Tag";
+import Text from "@components/common/Text";
+import ConfirmButton from "@components/common/Button/Confirm";
+import { Rating } from "@mui/material";
+
+const TodayChatItem = () => {
+  return (
+    <div className={styles.today__item}>
+      <div>
+        <Text types="sub-header" bold="semi-bold">
+          1
+        </Text>
+        <div></div>
+        <div className={styles.today__info}>
+          <Text types="title" bold="semi-bold">
+            웹툰 이름입니다.
+          </Text>
+          <Rating value={3} sx={{ fontSize: "12px" }} readOnly />
+          <Tag label="🔥 NNN" size="small" />
+        </div>
+      </div>
+      <ConfirmButton>참여</ConfirmButton>
+    </div>
+  );
+};
+
+export default TodayChatItem;

--- a/FE/src/components/home/feed/FeedItem.tsx
+++ b/FE/src/components/home/feed/FeedItem.tsx
@@ -1,0 +1,48 @@
+import styles from "@styles/home/Home.module.scss";
+import Text from "@components/common/Text";
+import Tag from "@components/common/Tag";
+import Profile from "@components/common/Profile";
+import Bookmark from "@components/common/Tag/Bookmark";
+import { Rating } from "@mui/material";
+import { useState } from "react";
+
+interface Props {
+  imgCount: number;
+}
+
+const FeedItem = ({ imgCount }: Props) => {
+  const [check, setCheck] = useState(false);
+
+  return (
+    <div className={styles.feed__item}>
+      {imgCount === 1 ? (
+        <div className={styles.feed__img}>
+          <div></div>
+        </div>
+      ) : (
+        <div className={styles.feed__imgs}>
+          {Array.from({ length: imgCount }, () => 0).map((_, key) => {
+            return <div key={key}></div>;
+          })}
+        </div>
+      )}
+      <div className={styles.feed__img}></div>
+      <div className={styles.feed__info}>
+        <div>
+          <Text>추천글 제목</Text>
+          <Rating defaultValue={3} sx={{ fontSize: "12px" }} readOnly />
+        </div>
+        <div className={styles.rest__tags}>
+          <Tag label="# 태그" types="gray" size="big" />
+          <Tag label="# 태그" types="gray" size="big" />
+        </div>
+        <div className={styles.feed__profile}>
+          <Profile name="Nickname" />
+          <Bookmark label="스크랩" checked={check} onChange={setCheck} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FeedItem;

--- a/FE/src/index.scss
+++ b/FE/src/index.scss
@@ -50,7 +50,8 @@
   --color-black: #000;
   --color-primary: #2b00d6;
   --color-secondary: #b8de2a;
-  --color-accent: #ff521d;
+  --color-accent-1: #ff521d;
+  --color-accent-2: #fe9ccd;
 
   --spacing-0: 0px;
   --spacing-1: 2px;
@@ -78,6 +79,10 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+html {
+  background-color: black;
 }
 
 body {

--- a/FE/src/main.tsx
+++ b/FE/src/main.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.scss";

--- a/FE/src/pages/ChatroomPage.tsx
+++ b/FE/src/pages/ChatroomPage.tsx
@@ -1,0 +1,37 @@
+import styles from "@styles/home/Home.module.scss";
+import ChatRoomList from "@components/home/chatroom/ChatRoomList";
+import MyChatRoom from "@components/home/chatroom/MyChatRoom";
+import RankingChat from "@components/home/chatroom/RankingChat";
+import RestChat from "@components/home/chatroom/RestChat";
+import TodayChat from "@components/home/chatroom/TodayChat";
+
+const CHAT_CONTENTS = [
+  {
+    title: "오늘 뜬 웹툰 Talk",
+    subtitle: "오늘 뜬 웹툰을 보고 다같이 이야기 나눠봐요!",
+    component: <TodayChat />,
+  },
+  {
+    title: "실시간 인기 Talk",
+    subtitle: "지금 가장 인기있는 웹툰에 대해 같이 이야기해요.",
+    component: <RankingChat />,
+  },
+  {
+    title: "이런 웹툰 Talk도 있어요!",
+    subtitle: "다른 사람들은 어떤 웹툰을 보고 있을까요?",
+    component: <RestChat />,
+  },
+];
+
+const ChatroomPage = () => {
+  return (
+    <div className={styles.chatroom}>
+      <MyChatRoom />
+      {CHAT_CONTENTS.map((item, key) => {
+        return <ChatRoomList key={key} title={item.title} subtitle={item.subtitle} component={item.component} />;
+      })}
+    </div>
+  );
+};
+
+export default ChatroomPage;

--- a/FE/src/pages/CommonPage.tsx
+++ b/FE/src/pages/CommonPage.tsx
@@ -11,7 +11,7 @@ import Arrow from "@components/common/Arrow";
 const CommonPage = () => {
   const [isChecked, setIsChecked] = useState(false);
   return (
-    <div>
+    <div style={{ margin: "0 20px" }}>
       <div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
         <Text types="caption">Caption caption, Regular</Text>
         <Text types="body-1">Body-1 body-1, Regular</Text>

--- a/FE/src/pages/HomePage.tsx
+++ b/FE/src/pages/HomePage.tsx
@@ -1,0 +1,17 @@
+import ButtomNav from "@components/home/BottomNav";
+import HomeTab from "@components/home/HomeTab";
+import Logo from "@components/common/Logo";
+import HomeRoutes from "@routes/HomeRoutes";
+
+const HomePage = () => {
+  return (
+    <>
+      <Logo />
+      <HomeTab />
+      <HomeRoutes />
+      <ButtomNav />
+    </>
+  );
+};
+
+export default HomePage;

--- a/FE/src/pages/RecommendPage.tsx
+++ b/FE/src/pages/RecommendPage.tsx
@@ -1,0 +1,15 @@
+import styles from "@styles/home/Home.module.scss";
+import FeedItem from "@/components/home/feed/FeedItem";
+
+const RecommendPage = () => {
+  return (
+    <div className={styles.feed}>
+      <FeedItem imgCount={1} />
+      <FeedItem imgCount={2} />
+      <FeedItem imgCount={3} />
+      <FeedItem imgCount={4} />
+    </div>
+  );
+};
+
+export default RecommendPage;

--- a/FE/src/routes/HomeRoutes.tsx
+++ b/FE/src/routes/HomeRoutes.tsx
@@ -1,0 +1,14 @@
+import { Routes, Route } from "react-router";
+import RecommendPage from "@pages/RecommendPage";
+import ChatroomPage from "@pages/ChatroomPage";
+
+const HomeRoutes = () => {
+  return (
+    <Routes>
+      <Route index path="/" element={<ChatroomPage />} />
+      <Route path="/recommend" element={<RecommendPage />} />
+    </Routes>
+  );
+};
+
+export default HomeRoutes;

--- a/FE/src/styles/common/Arrow.module.scss
+++ b/FE/src/styles/common/Arrow.module.scss
@@ -1,13 +1,14 @@
 .arrow {
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
   align-items: center;
-  gap: 3px;
+  margin-right: 0;
   width: 64px;
+  line-height: 100%;
   color: var(--color-gray-2);
   cursor: pointer;
 
-  & > svg {
+  > svg {
     font-size: large;
   }
 }

--- a/FE/src/styles/common/Logo.module.scss
+++ b/FE/src/styles/common/Logo.module.scss
@@ -1,0 +1,4 @@
+.logo {
+  padding: 2px 0 2px 5px;
+  box-sizing: border-box;
+}

--- a/FE/src/styles/common/Profile.module.scss
+++ b/FE/src/styles/common/Profile.module.scss
@@ -1,0 +1,5 @@
+.profile {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}

--- a/FE/src/styles/common/Tag.module.scss
+++ b/FE/src/styles/common/Tag.module.scss
@@ -1,5 +1,5 @@
 $font-size: 10px;
-$border-radius: 40px;
+$border-radius: 4px;
 
 %common {
   display: flex;
@@ -13,16 +13,17 @@ $border-radius: 40px;
 
 %small {
   width: 46px;
-  height: 22px;
+  height: 20px;
 }
 
 %big {
   width: 58px;
   height: 30px;
+  border-radius: 100px;
 }
 
 %primary {
-  background-color: var(--color-primary);
+  background: linear-gradient(45deg, #0038f5, #9f03ff);
 }
 
 %secondary {
@@ -30,7 +31,8 @@ $border-radius: 40px;
 }
 
 %gray {
-  background-color: var(--color-gray-2);
+  color: var(--color);
+  background-color: var(--color-gray-1);
 }
 
 .checkbox label {
@@ -58,7 +60,7 @@ $border-radius: 40px;
 
   & > label {
     @extend %common, %big;
-    background-color: var(--color-secondary);
+    background-color: var(--color-accent-1);
     line-height: 100%;
     cursor: pointer;
   }

--- a/FE/src/styles/home/Home.module.scss
+++ b/FE/src/styles/home/Home.module.scss
@@ -1,0 +1,267 @@
+.tabList {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.tab {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  width: 100%;
+  text-align: center;
+  cursor: pointer;
+
+  &__chat {
+    @extend .tab;
+    color: var(--color-gray-2);
+    &--clicked {
+      @extend .tab;
+      color: var(--color-primary);
+      > div {
+        border: 1.8px solid var(--color-primary);
+      }
+    }
+  }
+
+  &__feed {
+    @extend .tab;
+    color: var(--color-accent-1);
+    > div {
+      border: 1.8px solid var(--color-accent-1);
+    }
+    &--clicked {
+      @extend .tab;
+      color: var(--color-gray-2);
+    }
+  }
+}
+
+.nav {
+  width: 390px;
+  height: 88px;
+  position: fixed;
+  bottom: 0;
+  background-color: var(--color-white);
+
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+
+  > div {
+    padding-bottom: 32px;
+    box-sizing: border-box;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    &:nth-child(1) {
+      color: var(--color-primary);
+    }
+    &:nth-child(2),
+    &:nth-child(3) {
+      color: var(--color-gray-2);
+    }
+  }
+}
+
+.chatroom {
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+  margin: 0 40px;
+  margin-top: 40px;
+  margin-bottom: 88px; // 하단 네비 높이
+  &__title {
+    margin-bottom: 20px;
+    > div:nth-child(1) {
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 6px;
+    }
+
+    > span:nth-child(2) {
+      color: var(--color-gray-2);
+    }
+  }
+}
+
+.webtoon {
+  width: 100%;
+  overflow-x: auto;
+  margin-top: 10px;
+
+  // 스크롤 숨김
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera*/
+  }
+
+  &__items {
+    width: 100%;
+    display: grid;
+    gap: 15px;
+    grid-auto-flow: column;
+  }
+
+  &__item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-2);
+  }
+
+  &__img {
+    width: 66px;
+    height: 66px;
+    border-radius: 20px;
+    background-color: var(--color-gray-1);
+  }
+}
+
+.today {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+
+  &__item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    > div {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+
+      // 이미지
+      > div:nth-child(2) {
+        width: 46px;
+        height: 66px;
+        border-radius: 6px;
+        background-color: var(--color-gray-1);
+      }
+    }
+  }
+
+  &__info {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+}
+
+.ranking {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  // 이미지
+  &__item {
+    display: flex;
+    gap: 16px;
+  }
+
+  &__img {
+    position: relative;
+    width: 66px;
+    height: 66px;
+    border-radius: 20px;
+    background-color: var(--color-gray-1);
+
+    > div:nth-child(2) {
+      position: absolute;
+      right: 0;
+    }
+  }
+
+  &__comments {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.rest {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+
+  &__item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    > div {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+  }
+
+  &__tags {
+    display: flex;
+    gap: 2px;
+  }
+
+  &__img {
+    width: 66px;
+    height: 94px;
+    border-radius: 6px;
+    background-color: var(--color-gray-1);
+  }
+}
+
+.feed {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 40px;
+  margin-top: 30px;
+  padding-bottom: calc(100px + 20px); // 하단 네비 높이 + 그림자 여백
+
+  &__item {
+    width: 348px;
+    padding: 16px;
+    box-sizing: border-box;
+    border-radius: 20px;
+    box-shadow: 0 4px 14px rgb(0, 0, 0, 0.2);
+    cursor: pointer;
+  }
+
+  &__img {
+    > div {
+      height: 400px;
+      border-radius: 6px;
+      background-color: var(--color-gray-1);
+    }
+  }
+
+  &__imgs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    justify-items: center;
+    gap: 10px;
+    > div {
+      width: 153px;
+      height: 185px;
+      border-radius: 6px;
+      background-color: var(--color-gray-1);
+    }
+  }
+
+  &__info {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+
+    > div:nth-child(1) {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+  }
+
+  &__profile {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+}

--- a/FE/tsconfig.json
+++ b/FE/tsconfig.json
@@ -25,6 +25,7 @@
       "@/*": ["src/*"],
       "@assets/*": ["src/assets/*"],
       "@components/*": ["src/components/*"],
+      "@routes/*": ["src/routes/*"],
       "@hooks/*": ["src/hooks/*"],
       "@pages/*": ["src/pages/*"],
       "@slices/*": ["src/slices/*"],

--- a/FE/vite.config.ts
+++ b/FE/vite.config.ts
@@ -9,14 +9,15 @@ export default defineConfig({
   },
   resolve: {
     alias: [
-      { find: "@", replacement: "/src" },
       { find: "@assets", replacement: "/src/assets" },
       { find: "@components", replacement: "/src/components" },
+      { find: "@routes", replacement: "/src/routes" },
       { find: "@hooks", replacement: "/src/hooks" },
       { find: "@pages", replacement: "/src/pages" },
       { find: "@slices", replacement: "/src/slices" },
       { find: "@styles", replacement: "/src/styles" },
       { find: "@utils", replacement: "/src/utils" },
+      { find: "@", replacement: "/src" },
     ],
   },
 });


### PR DESCRIPTION
close #29 

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

### 1. 메인페이지 컴포넌트 생성
- 라우터 설정하면서, "HomeRoutes.tsx" 생성해 채팅은 "/home", 추천글은 "/home/recommend"로 경로를 설정했습니다.
- 하단 네비게이션은 프레임만 있고, 기능은 동작하지 않습니다. 클릭 시 색상 변경은 검색 페이지 개발 시 수정할 예정입니다.
### 2. 로고 컴포넌트 생성
- 현재 프레임만 있고, 추후 정해진 로고가 생기면 변경하겠습니다.
### 3. 프로필 컴포넌트 생성
- 메인 페이지에서 사용되는 프로필만 만들었는데, 다음 브랜치 파서 small, medium, large로 확장할 예정입니다.
### 4. "--host" 키워드 추가
- 모바일에서 로컬에 접속 가능합니다. (참고: https://calkolab.tistory.com/entry/2024-01-13)
 
## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
