### PR TITLE
[BE] 업데이트 예정 웹툰 기준 채팅방 조회 기능 추가

### DIFF
--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/controller/ChatRoomController.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/controller/ChatRoomController.java
@@ -32,4 +32,11 @@ public class ChatRoomController {
         return ApiResponse.createSuccess(chatRoomService.searchAllChatRoom(token));
     }
 
+    @GetMapping("/chatroom/search/updated-day")
+    public ApiResponse<List<ChatRoomInfoResponse>> searchUpdatedChatRoom(
+            @RequestHeader("Authorization") String token
+    ) {
+        return ApiResponse.createSuccess(chatRoomService.searchUpdatedChatRoom(token));
+    }
+
 }

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/entity/ChatRoom.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/entity/ChatRoom.java
@@ -4,6 +4,8 @@ import com.example.toonners.domain.toondata.entity.ToonData;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Builder
 @ToString
@@ -26,6 +28,7 @@ public class ChatRoom {
     private String contexts;
     private Long fireTotalCount;
     private Long fireTodayCount;
+    private String updatedDays;
 
     @OneToOne
     private ToonData toonData;

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/repository/ChatRoomRepository.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/repository/ChatRoomRepository.java
@@ -7,5 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ChatRoomReposititory extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    List<ChatRoom> findByUpdatedDaysLike(String day);
 }


### PR DESCRIPTION

close #

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 그 날 웹툰 업데이트 요일을 기준으로 채팅방 조회
- ex) 오늘이 월요일이면 월요일 업데이트 예정인 웹툰 관련한 채팅방 리스트 조회

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
