### PR TITLE
[BE] 업데이트 예정 웹툰 기준 채팅방 조회 기능에 오늘 날짜 계산하는 로직 추가

### DIFF
--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/service/ChatRoomService.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/service/ChatRoomService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -86,10 +87,31 @@ public class ChatRoomService {
         // 북마크 등 개인 상호 작용 결과 삽입을 위한 맴버 정보
         Long memberId = tokenProvider.getMemberFromToken(token).getId();
 
-        String day = "mon";
+        String day = whichDay();
         List<ChatRoom> chatRoomList = chatRoomRepository.findByUpdatedDaysLike(day);
 
         return chatRoomList.stream()
                 .map(ChatRoomInfoResponse::fromEntity).toList();
+    }
+
+    public static String whichDay() {
+        LocalDate date = LocalDate.now();
+        int day = date.getDayOfWeek().getValue();
+        if (day == 1) {
+            return "mon";
+        } else if (day == 2) {
+            return "tue";
+        } else if (day == 3) {
+            return "wed";
+        } else if (day == 4) {
+            return "thu";
+        } else if (day == 5) {
+            return "fri";
+        } else if (day == 6) {
+            return "sat";
+        } else if (day == 7) {
+            return "sun";
+        }
+        return null;
     }
 }


### PR DESCRIPTION

close #

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 테스트를 위해 월요일으로 고정해던 코드에서 '오늘' 요일에 맞춰 리스트 반환하게 변경.
- 리스트로 들어오는 요일들을 String 객체로 합치고, 오늘 요일을 그 String 문자가 포함하는지 판단하여 리스트 반환 

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
- [ ] 