### PR TITLE
[BE] 인기 채팅방 조회 반환 값에 채팅 내역 포함

### DIFF
--- a/BE/toonners/src/main/java/com/example/toonners/domain/chat/repository/ChatRepository.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chat/repository/ChatRepository.java
@@ -1,10 +1,14 @@
 package com.example.toonners.domain.chat.repository;
 
 import com.example.toonners.domain.chat.entity.Chat;
+import com.example.toonners.domain.chatRoom.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface ChatRepository extends JpaRepository<Chat, Long> {
     List<Chat> findAllByChatRoomId(Long chatroomId);
+    List<Chat> findTop3ByChatRoomOrderByCreatedAtDesc(ChatRoom chatRoom);
 }

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/controller/ChatRoomController.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/controller/ChatRoomController.java
@@ -59,11 +59,11 @@ public class ChatRoomController {
         return ApiResponse.createSuccess(chatRoomService
                 .searchAllChatRoomByPartOfChatRoomName(partOfChatRoomName));
     }
-    @GetMapping("/chatroom/search/top10")
-    public ApiResponse<List<ChatRoomInfoResponse>> searchChatRoomTop10(
+    @GetMapping("/chatroom/search/top3")
+    public ApiResponse<List<ChatRoomInfoResponse>> searchChatRoomTop3(
             @RequestHeader("Authorization") String token
     ) {
-        return ApiResponse.createSuccess(chatRoomService.searchChatRoomTop10(token));
+        return ApiResponse.createSuccess(chatRoomService.searchChatRoomTop3(token));
     }
 
 }

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/dto/response/ChatRoomInfoResponse.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/dto/response/ChatRoomInfoResponse.java
@@ -1,7 +1,10 @@
 package com.example.toonners.domain.chatRoom.dto.response;
 
+import com.example.toonners.domain.chat.dto.response.ChatInfoResponse;
 import com.example.toonners.domain.chatRoom.entity.ChatRoom;
 import lombok.*;
+
+import java.util.List;
 
 @Setter
 @Getter
@@ -17,6 +20,7 @@ public class ChatRoomInfoResponse {
     private Float rating;
     private String contexts;
     private Long fireTotalCount;
+    private List<ChatInfoResponse> chatList;
 
     public static ChatRoomInfoResponse fromEntity(ChatRoom chatRoom) {
         float rating = 0f;

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/repository/ChatRoomRepository.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/repository/ChatRoomRepository.java
@@ -16,5 +16,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     List<ChatRoom> findByToonNameContains(String partOfChatRoomName);
 
-    List<ChatRoom> findTop10ByOrderByFireTotalCountDesc();
+    List<ChatRoom> findTop3ByOrderByFireTotalCountDesc();
 }

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/service/ChatRoomService.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/service/ChatRoomService.java
@@ -1,6 +1,9 @@
 package com.example.toonners.domain.chatRoom.service;
 
 import com.example.toonners.config.jwt.TokenProvider;
+import com.example.toonners.domain.chat.dto.response.ChatInfoResponse;
+import com.example.toonners.domain.chat.entity.Chat;
+import com.example.toonners.domain.chat.repository.ChatRepository;
 import com.example.toonners.domain.chatRoom.dto.request.CreateChatRoomRequest;
 import com.example.toonners.domain.chatRoom.dto.response.ChatRoomInfoResponse;
 import com.example.toonners.domain.chatRoom.entity.ChatRoom;
@@ -27,6 +30,7 @@ public class ChatRoomService {
     private final TokenProvider tokenProvider;
     private final MemberRepository memberRepository;
     private final ToonDataRepository toonDataRepository;
+    private final ChatRepository chatRepository;
 
     @Transactional
     public ChatRoomInfoResponse createChatroom(
@@ -90,9 +94,15 @@ public class ChatRoomService {
     }
 
     @Transactional
-    public List<ChatRoomInfoResponse> searchChatRoomTop10(String token) {
-        List<ChatRoom> chatRoomList = chatRoomRepository.findTop10ByOrderByFireTotalCountDesc();
-        return chatRoomList.stream().map(ChatRoomInfoResponse::fromEntity).toList();
+    public List<ChatRoomInfoResponse> searchChatRoomTop3(String token) {
+        List<ChatRoom> chatRoomList = chatRoomRepository.findTop3ByOrderByFireTotalCountDesc();
+        List<ChatRoomInfoResponse> responseList = chatRoomList.stream()
+                .map(ChatRoomInfoResponse::fromEntity).toList();
+        for (int i = 0; i < responseList.size(); i++) {
+            List<Chat> chatList = chatRepository.findTop3ByChatRoomOrderByCreatedAtDesc(chatRoomList.get(i));
+            responseList.get(i).setChatList(chatList.stream().map(ChatInfoResponse::fromEntity).toList());
+        }
+        return responseList;
     }
 
     @Transactional


### PR DESCRIPTION

close #

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 최신 채팅 내역을 인기 채팅방 조회 시 반환 값으로 같이 삽입
- top 10 에서 top 3 으로 변경

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
