### PR TITLE
[BE] 피드 response 해시태그 2가지로 분류

### DIFF
--- a/BE/toonners/src/main/java/com/example/toonners/domain/feed/dto/response/FeedInfoResponse.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/feed/dto/response/FeedInfoResponse.java
@@ -21,7 +21,8 @@ public class FeedInfoResponse {
     private String writerMemberImage;
     private String feedTitle;
     private String feedContexts;
-    private Set<String> hashtags;
+    private Set<String> hashtagsVibe;
+    private Set<String> hashtagsGenre;
     private Set<ChildFeedResponse> childFeedList;
 
     private boolean bookmarked;
@@ -29,10 +30,12 @@ public class FeedInfoResponse {
     private Long likeCount;
 
     public static FeedInfoResponse fromEntity(Feed feed) {
-
-        String hasgtagsString = feed.getHashtagVibe() + feed.getHashtagGenre();
-        hasgtagsString = hasgtagsString.replaceAll("#", " ").trim();
-        Set<String> hashtagSet = new HashSet<>(Arrays.asList(hasgtagsString.split(" ")));
+        String hasgtagsVibeString = feed.getHashtagVibe();
+        hasgtagsVibeString = hasgtagsVibeString.replaceAll("#", " ").trim();
+        Set<String> hashtagVibeSet = new HashSet<>(Arrays.asList(hasgtagsVibeString.split(" ")));
+        String hasgtagsGenreString = feed.getHashtagGenre();
+        hasgtagsGenreString = hasgtagsGenreString.replaceAll("#", " ").trim();
+        Set<String> hashtagGenreSet = new HashSet<>(Arrays.asList(hasgtagsGenreString.split(" ")));
         return FeedInfoResponse.builder()
                 .parentFeedId(feed.getId())
                 .writerMemberId(feed.getWriter().getId())
@@ -40,7 +43,8 @@ public class FeedInfoResponse {
                 .writerMemberImage(feed.getWriter().getImage())
                 .feedTitle(feed.getTitle())
                 .feedContexts(feed.getContexts())
-                .hashtags(hashtagSet)
+                .hashtagsVibe(hashtagVibeSet)
+                .hashtagsGenre(hashtagGenreSet)
                 .childFeedList(feed.getChildFeedRequests().stream()
                         .map(ChildFeedResponse::fromRequest).collect(Collectors.toSet()))
                 .likeCount(feed.getLikeCounts())


### PR DESCRIPTION
close #

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [ ] feature 병합
- [ ] 버그 수정
- [x] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 수정 전 : vibe, genre 한 번에 모아서 response의 hashtags로 반환
- 수정 후 :  vibe, genre 따로 분류해서 반환

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
