### PR TITLE
[BE] 실시간 채팅방 조회를 위해 오늘 작성된 채팅 카운트

### DIFF
--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/ChatRoomScheduler.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/ChatRoomScheduler.java
@@ -1,0 +1,31 @@
+package com.example.toonners.domain.chatRoom;
+
+import com.example.toonners.domain.chatRoom.entity.ChatRoom;
+import com.example.toonners.domain.chatRoom.repository.ChatRoomRepository;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@EnableScheduling
+public class ChatRoomScheduler {
+
+    private final ChatRoomRepository ChatRoomRepository;
+
+    public ChatRoomScheduler(ChatRoomRepository ChatRoomRepository) {
+        this.ChatRoomRepository = ChatRoomRepository;
+    }
+
+    // 매일 오후 11시에 실행
+    @Transactional
+    @Scheduled(cron = "0 0 23 * * *")
+    public void resetChatCount() {
+        List<ChatRoom> chatRoomList = ChatRoomRepository.findByTodayChatCountIsNotNull();
+        for (ChatRoom chatRoom : chatRoomList) {
+            chatRoom.setTodayChatCount(null);
+        }
+    }
+}

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/controller/ChatRoomController.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/controller/ChatRoomController.java
@@ -66,4 +66,11 @@ public class ChatRoomController {
         return ApiResponse.createSuccess(chatRoomService.searchChatRoomTop3(token));
     }
 
+    @GetMapping("/chatroom/search/realtime-top5")
+    public ApiResponse<List<ChatRoomInfoResponse>> searchChatRoomRealTimeTop5(
+            @RequestHeader("Authorization") String token
+    ) {
+        return ApiResponse.createSuccess(chatRoomService.searchChatRoomTop5(token));
+    }
+
 }

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/dto/response/ChatRoomInfoResponse.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/dto/response/ChatRoomInfoResponse.java
@@ -21,6 +21,7 @@ public class ChatRoomInfoResponse {
     private String contexts;
     private Long fireTotalCount;
     private List<ChatInfoResponse> chatList;
+    private Long todayChatCount;
 
     public static ChatRoomInfoResponse fromEntity(ChatRoom chatRoom) {
         float rating = 0f;
@@ -35,6 +36,7 @@ public class ChatRoomInfoResponse {
                 .rating(rating)
                 .contexts(chatRoom.getContexts())
                 .fireTotalCount(chatRoom.getFireTotalCount())
+                .todayChatCount(chatRoom.getTodayChatCount())
                 .build();
     }
 }

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/entity/ChatRoom.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/entity/ChatRoom.java
@@ -25,8 +25,8 @@ public class ChatRoom {
     private Long ratingCount;
     private String contexts;
     private Long fireTotalCount;
-    private Long fireTodayCount;
     private String updatedDays;
+    private Long todayChatCount;
 
     @OneToOne
     private ToonData toonData;
@@ -44,7 +44,7 @@ public class ChatRoom {
         this.fireTotalCount = count;
     }
 
-    public void setFireTodayCount(Long count) {
-        this.fireTodayCount = count;
+    public void setTodayChatCount(Long count) {
+        this.todayChatCount = count;
     }
 }

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/repository/ChatRoomRepository.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/repository/ChatRoomRepository.java
@@ -17,4 +17,9 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     List<ChatRoom> findByToonNameContains(String partOfChatRoomName);
 
     List<ChatRoom> findTop3ByOrderByFireTotalCountDesc();
+
+    List<ChatRoom> findTop5ByOrderByTodayChatCountDescFireTotalCountDesc();
+
+    List<ChatRoom> findByTodayChatCountIsNotNull();
+
 }

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/service/ChatRoomService.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/service/ChatRoomService.java
@@ -12,7 +12,7 @@ import com.example.toonners.domain.member.repository.MemberRepository;
 import com.example.toonners.domain.toondata.entity.ToonData;
 import com.example.toonners.domain.toondata.repository.ToonDataRepository;
 import com.example.toonners.exception.chatRoom.ChatRoomAlreadyExistException;
-import com.example.toonners.exception.chatRoom.ChatRoomDoseNotExist;
+import com.example.toonners.exception.chatRoom.ChatRoomDoseNotExistException;
 import com.example.toonners.exception.member.UserDoesNotExistException;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -106,6 +106,18 @@ public class ChatRoomService {
     }
 
     @Transactional
+    public List<ChatRoomInfoResponse> searchChatRoomTop5(String token) {
+        List<ChatRoom> chatRoomList = chatRoomRepository.findTop5ByOrderByTodayChatCountDescFireTotalCountDesc();
+        List<ChatRoomInfoResponse> responseList = chatRoomList.stream()
+                .map(ChatRoomInfoResponse::fromEntity).toList();
+        for (int i = 0; i < responseList.size(); i++) {
+            List<Chat> chatList = chatRepository.findTop3ByChatRoomOrderByCreatedAtDesc(chatRoomList.get(i));
+            responseList.get(i).setChatList(chatList.stream().map(ChatInfoResponse::fromEntity).toList());
+        }
+        return responseList;
+    }
+
+    @Transactional
     public List<ChatRoomInfoResponse> searchUpdatedChatRoom(String token) {
 
         // 북마크 등 개인 상호 작용 결과 삽입을 위한 맴버 정보
@@ -121,7 +133,7 @@ public class ChatRoomService {
     @Transactional
     public ChatRoomInfoResponse searchChatRoomDetail(Long chatroomId) {
         return ChatRoomInfoResponse.fromEntity(chatRoomRepository
-                .findById(chatroomId).orElseThrow(ChatRoomDoseNotExist::new));
+                .findById(chatroomId).orElseThrow(ChatRoomDoseNotExistException::new));
     }
 
     @Transactional

--- a/BE/toonners/src/main/java/com/example/toonners/domain/fire/FireScheduler.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/fire/FireScheduler.java
@@ -1,0 +1,28 @@
+package com.example.toonners.domain.fire;
+
+import com.example.toonners.domain.fire.entity.Fire;
+import com.example.toonners.domain.fire.repository.FireRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+public class FireScheduler {
+
+    private final FireRepository fireRepository;
+
+    public FireScheduler(FireRepository fireRepository) {
+        this.fireRepository = fireRepository;
+    }
+
+    // 매일 0시에 실행
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    public void resetDailyFire() {
+        List<Fire> fireListToDelete = fireRepository.findAll();
+
+        fireRepository.deleteAll(fireListToDelete);
+    }
+}

--- a/BE/toonners/src/main/java/com/example/toonners/domain/fire/service/FireService.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/fire/service/FireService.java
@@ -7,7 +7,7 @@ import com.example.toonners.domain.fire.dto.request.CreateFireRequest;
 import com.example.toonners.domain.fire.entity.Fire;
 import com.example.toonners.domain.fire.repository.FireRepository;
 import com.example.toonners.domain.member.entity.Member;
-import com.example.toonners.exception.chatRoom.ChatRoomDoseNotExist;
+import com.example.toonners.exception.chatRoom.ChatRoomDoseNotExistException;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -28,9 +28,8 @@ public class FireService {
         //
         fireRepository.save(Fire.builder().member(member).chatRoomId(request.getChatRoomId()).build());
 
-        ChatRoom chatRoom = chatRoomRepository.findById(request.getChatRoomId()).orElseThrow(ChatRoomDoseNotExist::new);
+        ChatRoom chatRoom = chatRoomRepository.findById(request.getChatRoomId()).orElseThrow(ChatRoomDoseNotExistException::new);
         chatRoom.setFireTotalCount(chatRoom.getFireTotalCount() != null ? chatRoom.getFireTotalCount() + 1 : 1);
-        chatRoom.setFireTodayCount(chatRoom.getFireTodayCount() != null ? chatRoom.getFireTodayCount() + 1 : 1);
         chatRoomRepository.save(chatRoom);
 
         return "불 이모지 눌렀습니다.";

--- a/BE/toonners/src/main/java/com/example/toonners/exception/chatRoom/ChatRoomDoseNotExistException.java
+++ b/BE/toonners/src/main/java/com/example/toonners/exception/chatRoom/ChatRoomDoseNotExistException.java
@@ -2,8 +2,8 @@ package com.example.toonners.exception.chatRoom;
 
 import com.example.toonners.exception.errorCode.ErrorCode;
 
-public class ChatRoomDoseNotExist extends RuntimeException{
-    public ChatRoomDoseNotExist(){
+public class ChatRoomDoseNotExistException extends RuntimeException{
+    public ChatRoomDoseNotExistException(){
         super(ErrorCode.CHATROOM_DOSE_NOT_EXIST.getDescription());
     }
 }

--- a/BE/toonners/src/main/java/com/example/toonners/exception/handler/ChatRoomExceptionHandler.java
+++ b/BE/toonners/src/main/java/com/example/toonners/exception/handler/ChatRoomExceptionHandler.java
@@ -2,7 +2,7 @@ package com.example.toonners.exception.handler;
 
 import com.example.toonners.common.ApiResponse;
 import com.example.toonners.exception.chatRoom.ChatRoomAlreadyExistException;
-import com.example.toonners.exception.chatRoom.ChatRoomDoseNotExist;
+import com.example.toonners.exception.chatRoom.ChatRoomDoseNotExistException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,7 +14,7 @@ public class ChatRoomExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleChatRoomAlreadyExistException(RuntimeException exception) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(ApiResponse.createError(exception.getMessage()));
     }
-    @ExceptionHandler(ChatRoomDoseNotExist.class)
+    @ExceptionHandler(ChatRoomDoseNotExistException.class)
     public ResponseEntity<ApiResponse<?>> handleChatRoomDoseNotExist(RuntimeException exception) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(ApiResponse.createError(exception.getMessage()));
     }


### PR DESCRIPTION
close #

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 실시간 인기 채팅방 조회 시 실시간 성을 더하기 위해 오늘 채팅 개수 카운트
- 채팅방 entity에 todayChatCount 추가
- 채팅 작성할 때 마다 증가
- todayChatCount 매일 오후 11시 초기화
- TodayChatCount가 많은 순으로 실시간 인기 채팅방 조회 만약 개수가 같다면 FireTotalCount가 많은 것을 선택
관련 메서드 --> chatRoomRepository.findTop5ByOrderByTodayChatCountDescFireTotalCountDesc()
- fire 버튼(불이모지) 하루에 한 번 누룰수 있게 스케쥴링, fire 객체 일괄 삭제
## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
