### PR TITLE
[BE] 요일 기준으로 채팅방 조회

### DIFF
--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/controller/ChatRoomController.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/controller/ChatRoomController.java
@@ -39,6 +39,14 @@ public class ChatRoomController {
         return ApiResponse.createSuccess(chatRoomService.searchUpdatedChatRoom(token));
     }
 
+    @GetMapping("/chatroom/search/day")
+    public ApiResponse<List<ChatRoomInfoResponse>> searchChatRoomByDay(
+            @RequestHeader("Authorization") String token
+            , @RequestParam String day
+    ) {
+        return ApiResponse.createSuccess(chatRoomService.searchChatRoomByDay(token, day));
+    }
+
     @GetMapping("/chatroom/search/detail/{chatRoomId}")
     public ApiResponse<ChatRoomInfoResponse> searchChatRoomDetail(
             @PathVariable(value = "chatRoomId") Long chatRoomId
@@ -59,6 +67,7 @@ public class ChatRoomController {
         return ApiResponse.createSuccess(chatRoomService
                 .searchAllChatRoomByPartOfChatRoomName(partOfChatRoomName));
     }
+
     @GetMapping("/chatroom/search/top3")
     public ApiResponse<List<ChatRoomInfoResponse>> searchChatRoomTop3(
             @RequestHeader("Authorization") String token

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/service/ChatRoomService.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/service/ChatRoomService.java
@@ -131,6 +131,18 @@ public class ChatRoomService {
     }
 
     @Transactional
+    public List<ChatRoomInfoResponse> searchChatRoomByDay(String token, String day) {
+
+        // 북마크 등 개인 상호 작용 결과 삽입을 위한 맴버 정보
+        Long memberId = tokenProvider.getMemberFromToken(token).getId();
+
+        List<ChatRoom> chatRoomList = chatRoomRepository.findByUpdatedDaysLike(day);
+
+        return chatRoomList.stream()
+                .map(ChatRoomInfoResponse::fromEntity).toList();
+    }
+
+    @Transactional
     public ChatRoomInfoResponse searchChatRoomDetail(Long chatroomId) {
         return ChatRoomInfoResponse.fromEntity(chatRoomRepository
                 .findById(chatroomId).orElseThrow(ChatRoomDoseNotExistException::new));


### PR DESCRIPTION
close #

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 현재 업데이트 예정인 웹툰에 해당하는 채팅방을 불러오지 않는 오류 존재하여 테스트를 위한 기능 추가
- requestparam 으로 요일을 받아 그 요일에 해당하는 웹툰 방들을 조회.
- public List<ChatRoomInfoResponse> searchChatRoomByDay()
- public ApiResponse<List<ChatRoomInfoResponse>> searchChatRoomByDay ()

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
