### PR TITLE
[BE] 오늘 업데이트 예정인 웹툰 채팅방 조회 기능 수정

### DIFF
--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/repository/ChatRoomRepository.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/repository/ChatRoomRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    List<ChatRoom> findByUpdatedDaysLike(String day);
+    List<ChatRoom> findByUpdatedDaysContaining(String day);
 
     Optional<ChatRoom> findByToonName(String toonName);
 

--- a/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/service/ChatRoomService.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/chatRoom/service/ChatRoomService.java
@@ -125,7 +125,7 @@ public class ChatRoomService {
 
         String day = whichDay();
         System.out.println(day);
-        List<ChatRoom> chatRoomList = chatRoomRepository.findByUpdatedDaysLike(day);
+        List<ChatRoom> chatRoomList = chatRoomRepository.findByUpdatedDaysContaining(day);
 
         return chatRoomList.stream()
                 .map(ChatRoomInfoResponse::fromEntity).toList();
@@ -137,7 +137,7 @@ public class ChatRoomService {
         // 북마크 등 개인 상호 작용 결과 삽입을 위한 맴버 정보
         Long memberId = tokenProvider.getMemberFromToken(token).getId();
 
-        List<ChatRoom> chatRoomList = chatRoomRepository.findByUpdatedDaysLike(day);
+        List<ChatRoom> chatRoomList = chatRoomRepository.findByUpdatedDaysContaining(day);
 
         return chatRoomList.stream()
                 .map(ChatRoomInfoResponse::fromEntity).toList();

--- a/BE/toonners/src/main/resources/application.yml
+++ b/BE/toonners/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  jackson:
+    time-zone: Asia/Seoul
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
- 해당요일 포함해도 조회 할 수 있게 수정
  - 수정 전 : 업데이트 요일이 한 개일 경우에만 조회할 수 있었음
  - 수정 후 : 업데이트 요일이 다수일 경우에도 각 요일 마다 조회 가능 (ex : sun, thu 같은 경우 sunthu로 저장, 해당 요일을 포함하면 조회 가능)
  - findByUpdatedDaysContaining()
- 로컬개발환경과, 배포환경 동일한 시간대 사용하도록 설정
  -   jackson-time-zone: Asia/Seoul

close #

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [ ] feature 병합
- [x] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 해당요일 포함해도 조회 할 수 있게 수정
  - 수정 전 : 업데이트 요일이 한 개일 경우에만 조회할 수 있었음
  - 수정 후 : 업데이트 요일이 다수일 경우에도 각 요일 마다 조회 가능 (ex : sun, thu 같은 경우 sunthu로 저장, 해당 요일을 포함하면 조회 가능)
  - findByUpdatedDaysContaining()
- 로컬개발환경과, 배포환경 동일한 시간대 사용하도록 설정
  -   jackson-time-zone: Asia/Seoul

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
