### PR TITLE
[BE] 피드 db 구조 변경 후 조회 시 자식 피드 오류 수정

### DIFF
--- a/BE/toonners/src/main/java/com/example/toonners/domain/feed/dto/request/CreateFeedRequest.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/feed/dto/request/CreateFeedRequest.java
@@ -1,6 +1,6 @@
 package com.example.toonners.domain.feed.dto.request;
 
-import com.example.toonners.domain.feed.entity.ChildFeedRequest;
+import com.example.toonners.domain.feed.entity.ChildFeed;
 import lombok.*;
 
 import java.util.List;
@@ -15,6 +15,6 @@ public class CreateFeedRequest {
 
     private String title;
     private String context;
-    private List<ChildFeedRequest> recommendToons;
+    private List<ChildFeed> recommendToons;
 
 }

--- a/BE/toonners/src/main/java/com/example/toonners/domain/feed/dto/request/UpdateFeedRequest.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/feed/dto/request/UpdateFeedRequest.java
@@ -1,6 +1,6 @@
 package com.example.toonners.domain.feed.dto.request;
 
-import com.example.toonners.domain.feed.entity.ChildFeedRequest;
+import com.example.toonners.domain.feed.entity.ChildFeed;
 import lombok.*;
 
 import java.util.List;
@@ -14,5 +14,5 @@ import java.util.List;
 public class UpdateFeedRequest {
     private String title;
     private String context;
-    private List<ChildFeedRequest> recommendToons;
+    private List<ChildFeed> recommendToons;
 }

--- a/BE/toonners/src/main/java/com/example/toonners/domain/feed/dto/response/ChildFeedResponse.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/feed/dto/response/ChildFeedResponse.java
@@ -1,6 +1,6 @@
 package com.example.toonners.domain.feed.dto.response;
 
-import com.example.toonners.domain.feed.entity.ChildFeedRequest;
+import com.example.toonners.domain.feed.entity.ChildFeed;
 import lombok.*;
 
 import java.util.Set;
@@ -19,7 +19,7 @@ public class ChildFeedResponse {
     private String toonImage;
     private String toonSiteUrl;
 
-    public static ChildFeedResponse fromRequest(ChildFeedRequest request) {
+    public static ChildFeedResponse fromRequest(ChildFeed request) {
         return ChildFeedResponse.builder()
                 .starring(request.getStarring())
                 .hashtagGenre(request.getHashtagGenre())

--- a/BE/toonners/src/main/java/com/example/toonners/domain/feed/entity/ChildFeed.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/feed/entity/ChildFeed.java
@@ -15,7 +15,7 @@ import java.util.Set;
 @ToString
 @Builder
 @Entity(name = "CHILD_FEED_REQUEST")
-public class ChildFeedRequest {
+public class ChildFeed {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "CHILD_FEED_REQUEST_ID")

--- a/BE/toonners/src/main/java/com/example/toonners/domain/feed/entity/Feed.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/feed/entity/Feed.java
@@ -36,8 +36,8 @@ public class Feed extends BaseEntity {
 
     private Long likeCounts = 0L;
 
-    @OneToMany(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ChildFeedRequest> childFeedRequests = new LinkedList<>();
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChildFeed> childFeedRequests;
 
     public void updateFields(UpdateFeedRequest request) {
         if (request.getTitle() != null) {
@@ -45,9 +45,6 @@ public class Feed extends BaseEntity {
         }
         if (request.getContext() != null) {
             contexts = request.getContext();
-        }
-        if (request.getRecommendToons() != null) {
-            childFeedRequests = request.getRecommendToons();
         }
     }
 
@@ -61,5 +58,17 @@ public class Feed extends BaseEntity {
 
     public void setLikeCounts(Long counts) {
         this.likeCounts = counts;
+    }
+
+    public void setChildFeedRequests(List<ChildFeed> newChildFeeds) {
+        if (this.childFeedRequests == null) {
+            this.childFeedRequests = new LinkedList<>();
+        }
+        // 기존 리스트 클리어
+        this.childFeedRequests.clear();
+        // 새로운 리스트 추가
+        if (newChildFeeds != null) {
+            this.childFeedRequests.addAll(newChildFeeds);
+        }
     }
 }

--- a/BE/toonners/src/main/java/com/example/toonners/domain/feed/repository/ChildFeedRepository.java
+++ b/BE/toonners/src/main/java/com/example/toonners/domain/feed/repository/ChildFeedRepository.java
@@ -1,0 +1,10 @@
+package com.example.toonners.domain.feed.repository;
+
+import com.example.toonners.domain.feed.entity.ChildFeed;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChildFeedRepository extends JpaRepository<ChildFeed, Long> {
+
+}


### PR DESCRIPTION
close #

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [ ] feature 병합
- [x] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 문제 : 자식피드를 entity로 바꾼 후에 피드 조회 시 자식 피드가 반환를 반환하지 않음
- 원인 : 부모피드에 자식피드를 삽입할 때 entity 형식이 아닌 그 전 형식 그대로 저장하고 있었음
- 수정방식 : 자식피드 레포지토리 인터페이스 생성 및 자식피드를 객체를 만들고 저장 후 부모피드에 저장하도록 변경
- 피드생성, 피드수정 함수 안에서 자식피드 객체 생성 및 레포지토리에 저장
- 자식피드 클래스 네임을 childFeedRequest에서 entity 네임 형식인 childFeed로 변경

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
